### PR TITLE
Improve docs and add basic tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,11 @@ This document provides specific instructions for coding agents to engage with th
 4. **Submit Changes**:
    - Follow the process outlined in `CONTRIBUTING.md`.
 
+5. **Stay Curious**:
+   - If you notice a gap or missing explanation, create a conjecture describing
+     the problem and a possible approach.
+   - Agents are welcome to open pull requests to explore these ideas.
+
 ## Philosophy Alignment
 
 Helpful: read `README.md`.

--- a/README.md
+++ b/README.md
@@ -19,14 +19,6 @@ criticism. We aim to build clear explanations for why the current code exists.
 See [`conjectures/`](conjectures/) for open proposals and
 [`explanations.md`](explanations.md) for reasoning that has survived criticism.
 
-## Philosophy
-
-Software design here is always tentative. Inspired by Popper's critical
-rationalism, each implementation choice is treated as a **conjecture** subject to
-criticism. We aim to build clear explanations for why the current code exists.
-See [`conjectures/`](conjectures/) for open proposals and
-[`explanations.md`](explanations.md) for reasoning that has survived criticism.
-
 ## Development Culture
 
 1. **Conjecture First** – New ideas or features begin as conjectures.  Create a
@@ -55,8 +47,12 @@ uvicorn app:app --reload
 # Frontend
 cd src
 npm install
-$env:NODE_OPTIONS='--openssl-legacy-provider'; npm start
+$env:NODE_OPTIONS='--openssl-legacy-provider'; npm start
 ```
+## Running Tests
+
+Use `pytest` to run backend tests. See `TESTING.md` for more information.
+
 ## For Agents
 
 Conjecture: It would be useful to check out `AGENTS.md`.

--- a/conjectures/token_expiry.md
+++ b/conjectures/token_expiry.md
@@ -1,0 +1,11 @@
+# Shorter Token Expiry
+
+## Problem
+Current access tokens last 60 minutes in `create_access_token`. This may be too long for small sessions and could expose accounts if a token leaks.
+
+## Tentative Approach
+Make the expiry configurable via an environment variable (e.g., `TOKEN_MINUTES`). Use this value when generating tokens.
+
+## Initial Reasoning
+Adjustable expiry lets us experiment with trade-offs between convenience and security. It also encourages documentation of why a specific duration was chosen.
+

--- a/explanations.md
+++ b/explanations.md
@@ -15,3 +15,10 @@ registration or content moderation are approached as provisional solutions that
 may be replaced once we find better explanations. Recording those insights here
 helps new contributors understand the path of ideas.
 
+## The Role of Testing
+
+Automated tests serve as conjectures about how the code should behave. When
+a test fails, it acts as immediate criticism that guides us toward a better
+explanation or implementation. Maintaining even small test suites keeps the
+project improvable and documents expected behaviour for newcomers.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ transformers
 motor
 pydantic[email]
 python-dotenv
+
+passlib
+python-jose

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+# Ensure the project root is on the path and set a test secret before imports
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+os.environ["JWT_SECRET"] = "testsecret"
+
+from auth.utils import hash_password, verify_password, create_access_token
+from jose import jwt
+
+def test_hash_and_verify_password():
+    hashed = hash_password("secret")
+    assert hashed != "secret"
+    assert verify_password("secret", hashed)
+
+
+def test_create_access_token():
+    os.environ["JWT_SECRET"] = "testsecret"
+    token = create_access_token({"sub": "user@example.com"}, expires_delta=1)
+    decoded = jwt.decode(token, os.environ["JWT_SECRET"], algorithms=["HS256"])
+    assert decoded["sub"] == "user@example.com"
+


### PR DESCRIPTION
## Summary
- remove duplicate Philosophy section in README
- mention how to run tests
- encourage agents to open conjectures in `AGENTS.md`
- document why tests matter
- add example conjecture about token expiry
- add `passlib` and `python-jose` to requirements
- implement basic test suite for auth utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870c2b1735c832d97781b145e3c725c