### PR TITLE
Implement Open Ideas minimal prototype

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from transformers import BertTokenizer, BertForSequenceClassification
 import torch
 from routes.auth_routes import router as AuthRouter
+from routes.idea_routes import router as IdeaRouter
 app = FastAPI()
 
 # Enable CORS
@@ -29,6 +30,7 @@ class TweetText(BaseModel):
 # Prediction endpoint
 
 app.include_router(AuthRouter)
+app.include_router(IdeaRouter)
 @app.post("/predict")
 def predict_tweet(tweet: TweetText):
     inputs = tokenizer(tweet.text, return_tensors="pt", padding=True, truncation=True).to(device)

--- a/models/idea.py
+++ b/models/idea.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class Idea(BaseModel):
+    id: int
+    title: str
+    body: str
+    idea_type: str
+    parent_id: Optional[int] = None

--- a/routes/idea_routes.py
+++ b/routes/idea_routes.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, HTTPException
+from typing import List
+from models.idea import Idea
+
+router = APIRouter()
+
+# In-memory storage
+ideas: List[Idea] = []
+current_id = 1
+
+@router.get('/ideas', response_model=List[Idea])
+async def list_ideas():
+    return ideas
+
+@router.post('/ideas', response_model=Idea)
+async def create_idea(idea: Idea):
+    global current_id
+    idea.id = current_id
+    current_id += 1
+    ideas.append(idea)
+    return idea
+
+@router.get('/ideas/{idea_id}', response_model=Idea)
+async def get_idea(idea_id: int):
+    for idea in ideas:
+        if idea.id == idea_id:
+            return idea
+    raise HTTPException(status_code=404, detail='Idea not found')
+
+@router.post('/ideas/{idea_id}/criticize', response_model=Idea)
+async def add_criticism(idea_id: int, idea: Idea):
+    idea.parent_id = idea_id
+    idea.idea_type = 'criticism'
+    return await create_idea(idea)
+
+@router.post('/ideas/{idea_id}/synthesize', response_model=Idea)
+async def add_synthesis(idea_id: int, idea: Idea):
+    idea.parent_id = idea_id
+    idea.idea_type = 'synthesis'
+    return await create_idea(idea)
+
+@router.post('/ideas/{idea_id}/fork', response_model=Idea)
+async def fork_idea(idea_id: int, idea: Idea):
+    idea.parent_id = idea_id
+    idea.idea_type = 'conjecture'
+    return await create_idea(idea)

--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,11 @@
 import React from "react";
-import Sidebar from "./Sidebar";
-import Feed from "./Feed";
-import Widgets from "./Widgets";
 import "./App.css";
+import IdeaBoard from "./IdeaBoard";
 
 function App() {
   return (
     <div className="app">
-      <Sidebar />
-      <Feed />
-      <Widgets />
+      <IdeaBoard />
     </div>
   );
 }

--- a/src/IdeaBoard.js
+++ b/src/IdeaBoard.js
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+import IdeaForm from './IdeaForm';
+
+function IdeaBoard() {
+  const [ideas, setIdeas] = useState([]);
+  const apiUrl = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+
+  const loadIdeas = async () => {
+    const res = await fetch(`${apiUrl}/ideas`);
+    const data = await res.json();
+    setIdeas(data);
+  };
+
+  useEffect(() => { loadIdeas(); }, []);
+
+  const handleNewIdea = async (idea) => {
+    await fetch(`${apiUrl}/ideas`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(idea)
+    });
+    loadIdeas();
+  };
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>Open Ideas</h2>
+      <IdeaForm onSubmit={handleNewIdea} />
+      <ul>
+        {ideas.map((i) => (
+          <li key={i.id}>
+            <strong>[{i.idea_type}]</strong> {i.title}
+            <p>{i.body}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default IdeaBoard;

--- a/src/IdeaForm.js
+++ b/src/IdeaForm.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+
+function IdeaForm({ onSubmit }) {
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [ideaType, setIdeaType] = useState('conjecture');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!title || !body) return;
+    onSubmit({ id: 0, title, body, idea_type: ideaType });
+    setTitle('');
+    setBody('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
+      <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Title" />
+      <textarea value={body} onChange={(e) => setBody(e.target.value)} placeholder="Body" />
+      <select value={ideaType} onChange={(e) => setIdeaType(e.target.value)}>
+        <option value="conjecture">Conjecture</option>
+        <option value="criticism">Criticism</option>
+        <option value="synthesis">Synthesis</option>
+      </select>
+      <button type="submit">Post</button>
+    </form>
+  );
+}
+
+export default IdeaForm;


### PR DESCRIPTION
## Summary
- add `Idea` pydantic model
- implement FastAPI router for idea CRUD and threaded posts
- expose router in `app.py`
- create simple React `IdeaBoard` and `IdeaForm` components
- update `App.js` to show new board

## Testing
- `pytest -q`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711d727088832d90938dd6b689d9a9